### PR TITLE
fix: update CVE-2024-21626 rule

### DIFF
--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -36,7 +36,7 @@ var RULES = []common.Rule{
 		Name: "runc process.cwd & Leaked fds Container Breakout",
 		Blogpost: "https://snyk.io/blog/cve-2024-21626-runc-process-cwd-container-breakout",
 		Inst:        "WORKDIR",
-		ArgRegex:    regexp2.MustCompile("/proc/self/fd/", 0),
+		ArgRegex:    regexp2.MustCompile("/proc/self/fd", 0),
 	},
 	common.Rule{
 		ID: 2,


### PR DESCRIPTION
This fix is to cover also the case of the WORKDIR in Dockerfile being present without the slash 