### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A static analysis based exploit detector for runc and Docker vulnerabilities.
 CVE-2024-21626 is a vulnerability in the `runc` container runtime allowing an attacker to break out of the container isolation and achieve full root RCE via a crafted image that exploits an issue within the `WORKDIR` instruction's handling. Since there's a "race" condition between the time some file descriptors to the host are opened and closed, an attacker can create a Dockerfile with the following instruction `WORKDIR /proc/self/fd/[ID]` (with ID being a system dependent file descriptor) that will point to the underlying host machine's file system. This can be exploited when running:
 
 1. `docker build` - In 2 cases:
-   - When the Dockerfile being built contains the exploit triggerting instruction.
+   - When the Dockerfile being built contains the exploit triggering instruction.
    - When the Dockerfile being built refers to a base image via the `FROM` instruction that contains an `ONBUILD` command triggering the exploit e.e. `ONBUILD WORKDIR /proc/self/fd/[ID]`. The `ONBUILD` instruction injects the command not in the image that contains it but in the image that uses it as a base image. This means that if a base image is compromised or intentionally nefarious i.e. hosted on Dockerhub or other public container registries, exploitation if possible even if nothing changes in the image that the `docker build` command actually builds.
 2. `docker run`
 
@@ -156,5 +156,3 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 ## License
 
 Leaky Vessels Static Detector is under the Apache 2.0 License. See [LICENSE](LICENSE) for more information.
-
-

--- a/gh_crawler/README.md
+++ b/gh_crawler/README.md
@@ -6,7 +6,7 @@
    - `TARGET_ORG`: the name of the GitHUb organisation to crawl, example `snyk`
    - `GH_TOKEN`: a GitHub token with read permissions on all the repositories
    - `DH_USERNAME`: (Optional) Docker hub username to access base image history from Dockerhub
-   - `DH_PASSWORD_OR_PAT`: (Optional) Docker hub passwor to access base image history from Dockerhub
+   - `DH_PASSWORD_OR_PAT`: (Optional) Docker hub password to access base image history from Dockerhub
    - `GOOGLE_SERVICE_ACCOUNT_JSON`: (Optional) Google Cloud SA key for accessing the container registry
 
 ### Running from Code

--- a/main.go
+++ b/main.go
@@ -44,8 +44,8 @@ func setupCommonFlags() {
 	for _, fs := range []*flag.FlagSet{imageSubcmd, dockerfileSubcmd} {
 		fs.BoolVar(&debug, "debug", false, "Enable debug logs.")
 		fs.StringVar(&envFilePath, "env", "", "Path to .env file.")
-		fs.StringVar(&disable, "disable", "", 
-			`Comma-seperated list of rule ids to turn off. List of rule Ids: 
+		fs.StringVar(&disable, "disable", "",
+			`Comma-separated list of rule ids to turn off. List of rule Ids:
 1 - runc process.cwd & Leaked fds Container Breakout [CVE-2024-21626]
 2 - Buildkit Mount Cache Race: Build-time Race Condition Container Breakout [CVE-2024-23651]
 3 - Buildkit GRPC SecurityMode Privilege Check [CVE-2024-23653]


### PR DESCRIPTION
This PR fixes typos in the documentation and the "disable" option's description.