### PR TITLE
Add ability to download container images when not available locally

### DIFF
--- a/internal/sources/daemon/daemon.go
+++ b/internal/sources/daemon/daemon.go
@@ -63,9 +63,15 @@ func (d *DaemonAnalyzer) Setup() (error) {
     }
 
 	if !isLocal {
-		errMsg := fmt.Sprintf("%s is not found in local docker daemon images list.", d.ImageName)
-		log.Error(errMsg)
-		return errors.New(errMsg)
+		dbgMsg := fmt.Sprintf("Image not found locally, downloading it now from %s", d.ImageName)
+		log.Debug(dbgMsg)
+		reader, err := cli.ImagePull(context.Background(), d.ImageName, types.ImagePullOptions{})
+		if err != nil {
+			errMsg := fmt.Sprintf("Failed to pull image %s: %v", d.ImageName, err)
+			log.Error(errMsg)
+			return errors.New(errMsg)
+		}
+		defer reader.Close()
 	}
 
 	dbgMsg := fmt.Sprintf("Getting docker image layer history for %s", d.ImageName)


### PR DESCRIPTION
Static detector tool lacks the ability to pull images and only performs analysis on the container image available on the system. This PR adds ability to download container images using the docker daemon process to perform analysis on the base image. 

Please let me know what y'all think. Happy to discuss and get this merged in