### PR TITLE
Fix nil pointer dereference and resource leak in HTTP helpers

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -64,14 +64,19 @@ func GetJson(url string, token string) (string, error){
 	}
   
 	res, err := client.Do(req)
+	if err != nil {
+		errMsg := fmt.Sprintf("HTTP request failed: %s\n", err)
+		log.Debug(errMsg)
+		return "", errors.New(errMsg)
+	}
+	defer res.Body.Close()
+
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not read response body: %s\n", err)
 		log.Debug(errMsg)
 		return "", errors.New(errMsg)
 	}
-
-	defer res.Body.Close()
 
 	switch res.StatusCode{
 	case 200:
@@ -99,14 +104,19 @@ func PostJson(url string, body string, token string) (string, error) {
 	}
   
 	res, err := client.Do(req)
+	if err != nil {
+		errMsg := fmt.Sprintf("HTTP request failed: %s\n", err)
+		log.Debug(errMsg)
+		return "", errors.New(errMsg)
+	}
+	defer res.Body.Close()
+
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		errMsg := fmt.Sprintf("Could not read response body: %s\n", err)
 		log.Debug(errMsg)
 		return "", errors.New(errMsg)
 	}
-
-	defer res.Body.Close()
 
 	switch res.StatusCode{
 	case 200:


### PR DESCRIPTION
In `GetJson` and `PostJson` in `internal/common/utils.go`, the error from `client.Do()` was silently ignored and the response (which may be nil) was passed directly to `io.ReadAll`, causing a nil pointer dereference panic on HTTP transport failures.

Additionally, `defer res.Body.Close()` was placed after the `io.ReadAll` error check, meaning the response body would not be closed when `io.ReadAll` returned an error.

**Changes:**
- Add error check after `client.Do()` before accessing `res.Body`
- Move `defer res.Body.Close()` immediately after the Do() error check so the body is always closed even when `io.ReadAll` fails